### PR TITLE
feat(image): add path-style URL gen for MinIO

### DIFF
--- a/src/main/java/ru/pp/gamma/overlord/generation/pipeline/step/GenerateImagesStep.java
+++ b/src/main/java/ru/pp/gamma/overlord/generation/pipeline/step/GenerateImagesStep.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import ru.pp.gamma.overlord.ai.api.AiImageClient;
 import ru.pp.gamma.overlord.generation.pipeline.model.PresentationGenerationContext;
 import ru.pp.gamma.overlord.image.entity.Image;
+import ru.pp.gamma.overlord.image.enums.ImageFormat;
 import ru.pp.gamma.overlord.image.service.ImageService;
 import ru.pp.gamma.overlord.presentation.entity.Presentation;
 import ru.pp.gamma.overlord.presentation.entity.SlideField;
@@ -41,7 +42,7 @@ public class GenerateImagesStep implements PresentationGenerationStep {
                 templateImage.get("height").asInt(),
                 templateImage.get("width").asInt()
         );
-        String name = imageService.save(imageBytes);
+        String name = imageService.save(imageBytes, ImageFormat.JPEG);
 
         Image image = new Image();
         image.setName(name);

--- a/src/main/java/ru/pp/gamma/overlord/image/enums/ImageFormat.java
+++ b/src/main/java/ru/pp/gamma/overlord/image/enums/ImageFormat.java
@@ -1,0 +1,17 @@
+package ru.pp.gamma.overlord.image.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageFormat {
+    JPEG("jpeg", "image/jpeg"),
+    PNG("png", "image/png");
+
+    private final String extension;
+    private final String mimeType;
+
+    ImageFormat(String extension, String mimeType) {
+        this.extension = extension;
+        this.mimeType = mimeType;
+    }
+}

--- a/src/main/java/ru/pp/gamma/overlord/image/props/MinioProps.java
+++ b/src/main/java/ru/pp/gamma/overlord/image/props/MinioProps.java
@@ -15,5 +15,6 @@ public class MinioProps {
     private String utilBucket;
     private String connectUrl;
     private String publicDomain;
+    private Boolean usePathStyle;
 
 }

--- a/src/main/java/ru/pp/gamma/overlord/image/service/ImageService.java
+++ b/src/main/java/ru/pp/gamma/overlord/image/service/ImageService.java
@@ -1,10 +1,11 @@
 package ru.pp.gamma.overlord.image.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import ru.pp.gamma.overlord.common.util.MinioRepository;
+import ru.pp.gamma.overlord.image.enums.ImageFormat;
 import ru.pp.gamma.overlord.image.props.MinioProps;
 
 import java.util.Arrays;
@@ -14,40 +15,31 @@ import java.util.UUID;
 @Service
 public class ImageService {
 
-    private static final String EXTENSION = "jpeg";
-    private static final String MIME_TYPE = "image/jpeg";
-    private static final String EXTENSION_PNG = "png";
-    private static final String MIME_TYPE_PNG = "image/png";
-
-    @Value("${minio.bucket}")
-    private String bucket;
-
     private final MinioRepository minioRepository;
     private final MinioProps minioProps;
     private final Environment environment;
 
-    public String save(byte[] image) {
-        String name = generateName(EXTENSION);
-        minioRepository.put(bucket, name, MIME_TYPE, image);
-        return name;
+    private String baseImageUrl;
+
+    @PostConstruct
+    private void init() {
+        String scheme = Arrays.asList(environment.getActiveProfiles()).contains("prod")
+                ? "https" : "http";
+
+        if (Boolean.TRUE.equals(minioProps.getUsePathStyle())) {
+            baseImageUrl = scheme + "://" + minioProps.getPublicDomain() + "/" + minioProps.getBucket() + "/";
+        } else {
+            baseImageUrl = scheme + "://" + minioProps.getBucket() + "." + minioProps.getPublicDomain() + "/";
+        }
     }
 
-    public String savePng(byte[] image) {
-        String name = generateName(EXTENSION_PNG);
-        minioRepository.put(bucket, name, MIME_TYPE_PNG, image);
+    public String save(byte[] image, ImageFormat format) {
+        String name = UUID.randomUUID() + "." + format.getExtension();
+        minioRepository.put(minioProps.getBucket(), name, format.getMimeType(), image);
         return name;
     }
 
     public String generateUrlByName(String imageName) {
-        String protocol = isProd() ? "https://" : "http://";
-        return protocol + minioProps.getBucket() + "." + minioProps.getPublicDomain() + "/" + imageName;
-    }
-
-    private boolean isProd() {
-        return Arrays.asList(environment.getActiveProfiles()).contains("prod");
-    }
-
-    private String generateName(String extension) {
-        return UUID.randomUUID().toString() + "." + extension;
+        return baseImageUrl + imageName;
     }
 }

--- a/src/main/java/ru/pp/gamma/overlord/presentationpreview/listener/PresentationCreatedOrUpdatedListener.java
+++ b/src/main/java/ru/pp/gamma/overlord/presentationpreview/listener/PresentationCreatedOrUpdatedListener.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionTemplate;
 import ru.pp.gamma.overlord.export.image.ImageExportService;
 import ru.pp.gamma.overlord.image.entity.Image;
+import ru.pp.gamma.overlord.image.enums.ImageFormat;
 import ru.pp.gamma.overlord.image.repository.ImageRepository;
 import ru.pp.gamma.overlord.image.service.ImageService;
 import ru.pp.gamma.overlord.kafka.message.PresentationSavedOrUpdatedMessage;
@@ -51,7 +52,7 @@ public class PresentationCreatedOrUpdatedListener {
 
         // 2. Сохраняем в minio
         List<Image> imageEntities = images.stream()
-                .map(imageService::savePng)
+                .map(img -> imageService.save(img, ImageFormat.PNG))
                 .map(name -> new Image()
                         .setName(name))
                 .toList();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ minio:
   util-bucket: ${MINIO_BUCKET_UTIL:util}
   connect-url: ${MINIO_CONNECTION_URL:http://localhost:9000}
   public-domain: ${MINIO_PUBLIC_DOMAIN:localhost:9000}
+  use-path-style: ${MINIO_PATH_STYLE:false}
 
 collabora:
   url: ${COLLABORA_URL:http://localhost:9980}


### PR DESCRIPTION
Для алт деплоя (для универсальности, типа в env прописываем и по другому работает), через cf tunnel не дает сделать норм с под-под доменами...

По умолчанию будет работать также как было до PR, но если уже в env прописать MINIO_PATH_STYLE=true то будет применяться вот так: 
http://images.localhost:9000/ -> http://localhost:9000/images/